### PR TITLE
🚀 修复添加cookies的BUG，提高健壮性，同时新增获取cookies，查看可用cookies数

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,16 +72,16 @@ async def cron_refresh_cookies():
         logging.info(f"==========================================")
         logging.info("开始更新数据库里的 cookies.........")
         cookies = [item['cookie'] for item in await db_manager.get_cookies()]
-        semaphore = asyncio.Semaphore(10)
+        semaphore = asyncio.Semaphore(5)
         add_tasks = []
 
-        async def add_cookie(simple_cookie):
+        async def refresh_cookie(simple_cookie):
             async with semaphore:
-                return await fetch_limit_left(simple_cookie)
+                return await fetch_limit_left(simple_cookie, False)
 
         # 使用 asyncio.create_task 而不是直接 await
         for cookie in cookies:
-            add_tasks.append(add_cookie(cookie))
+            add_tasks.append(refresh_cookie(cookie))
 
         results = await asyncio.gather(*add_tasks, return_exceptions=True)
         success_count = sum(1 for result in results if result is True)
@@ -464,24 +464,40 @@ async def verify_auth_header(authorization: str = Header(...)):
         raise HTTPException(status_code=403, detail="Invalid authorization key")
 
 
-# 获取cookie
+# 获取cookies的详细详细
 @app.post(f"{COOKIES_PREFIX}/cookies")
 async def get_cookies(authorization: str = Header(...)):
     try:
         await verify_auth_header(authorization)
+
         cookies = await db_manager.get_all_cookies()
+        cookies_json = json.loads(cookies)
+        valid_cookie_count = int(await db_manager.get_valid_cookies_count())
+        invalid_cookie_count = len(cookies_json) - valid_cookie_count
         remaining_count = int(await db_manager.get_cookies_count())
+
         if remaining_count is None:
             remaining_count = 0
-        cookies_json = json.loads(cookies)
+
         logging.info({"message": "Cookies 获取成功。", "数量": len(cookies_json)})
-        logging.info("剩余数量:" + str(remaining_count))
+        logging.info("有效数量: " + str(valid_cookie_count))
+        logging.info("无效数量: " + str(invalid_cookie_count))
+        logging.info("剩余数量: " + str(remaining_count))
+
         return JSONResponse(
-            content={"cookie_count": len(cookies_json), "remaining_count": remaining_count, "cookies": cookies_json})
+            content={
+                "cookie_count": len(cookies_json),
+                "valid_cookie_count": valid_cookie_count,
+                "invalid_cookie_count": invalid_cookie_count,
+                "remaining_count": remaining_count,
+                "cookies": cookies_json
+            }
+        )
     except HTTPException as http_exc:
         raise http_exc
     except Exception as e:
-        return JSONResponse(status_code=500, content={"error": e})
+        logging.error(f"Unexpected error: {e}")
+        return JSONResponse(status_code=500, content={"error": str(e)})
 
 
 # 添加cookies
@@ -490,12 +506,12 @@ async def add_cookies(data: schemas.Cookies, authorization: str = Header(...)):
     try:
         await verify_auth_header(authorization)
         cookies = data.cookies
-        semaphore = asyncio.Semaphore(10)
+        semaphore = asyncio.Semaphore(5)
         add_tasks = []
 
         async def add_cookie(simple_cookie):
             async with semaphore:
-                return await fetch_limit_left(simple_cookie)
+                return await fetch_limit_left(simple_cookie, True)
 
         # 使用 asyncio.create_task 而不是直接 await
         for cookie in cookies:
@@ -547,16 +563,16 @@ async def refresh_cookies(authorization: str = Header(...)):
         logging.info(f"==========================================")
         logging.info("开始更新数据库里的 cookies.........")
         cookies = [item['cookie'] for item in await db_manager.get_cookies()]
-        semaphore = asyncio.Semaphore(10)
+        semaphore = asyncio.Semaphore(5)
         add_tasks = []
 
-        async def add_cookie(simple_cookie):
+        async def refresh_cookie(simple_cookie):
             async with semaphore:
-                return await fetch_limit_left(simple_cookie)
+                return await fetch_limit_left(simple_cookie, False)
 
         # 使用 asyncio.create_task 而不是直接 await
         for cookie in cookies:
-            add_tasks.append(add_cookie(cookie))
+            add_tasks.append(refresh_cookie(cookie))
 
         results = await asyncio.gather(*add_tasks, return_exceptions=True)
         success_count = sum(1 for result in results if result is True)
@@ -575,11 +591,13 @@ async def refresh_cookies(authorization: str = Header(...)):
 
 
 # 添加cookie的函数
-async def fetch_limit_left(cookie):
+async def fetch_limit_left(cookie, is_insert: bool = False):
     song_gen = SongsGen(cookie)
     try:
         remaining_count = song_gen.get_limit_left()
-        # logging.info(f"该账号剩余次数: {remaining_count}")
+        logging.info(f"该账号剩余次数: {remaining_count}")
+        if remaining_count == -1 and is_insert:
+            return False
         await db_manager.insert_or_update_cookie(cookie=cookie, count=remaining_count)
         return True
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -483,7 +483,7 @@ async def get_cookies(authorization: str = Header(...)):
         logging.info({"message": "Cookies 获取成功。", "数量": len(cookies_json)})
         logging.info("有效数量: " + str(valid_cookie_count))
         logging.info("无效数量: " + str(invalid_cookie_count))
-        logging.info("剩余数量: " + str(remaining_count))
+        logging.info("剩余创作音乐次数: " + str(remaining_count))
 
         return JSONResponse(
             content={

--- a/sql_uilts.py
+++ b/sql_uilts.py
@@ -215,6 +215,13 @@ class DatabaseManager:
                 await cur.execute("SELECT cookie FROM suno2openai")
                 return await cur.fetchall()
 
+    # 获取 invalid_cookies
+    async def get_invalid_cookies(self):
+        async with self.pool.acquire() as conn:
+            async with conn.cursor(aiomysql.DictCursor) as cur:
+                await cur.execute("SELECT cookie FROM suno2openai WHERE count > 0")
+                return await cur.fetchall()
+
     # 获取 cookies 和 count
     async def get_all_cookies(self):
         async with self.pool.acquire() as conn:

--- a/sql_uilts.py
+++ b/sql_uilts.py
@@ -201,7 +201,7 @@ class DatabaseManager:
         try:
             async with self.pool.acquire() as conn:
                 async with conn.cursor(aiomysql.DictCursor) as cur:
-                    await cur.execute("SELECT COUNT(cookie) AS total_count FROM suno2openai WHERE count > 0")
+                    await cur.execute("SELECT COUNT(cookie) AS total_count FROM suno2openai WHERE count >= 0")
                     result = await cur.fetchone()
                     return result['total_count'] if result['total_count'] is not None else 0
         except Exception as e:

--- a/sql_uilts.py
+++ b/sql_uilts.py
@@ -192,8 +192,20 @@ class DatabaseManager:
                     await cur.execute("SELECT SUM(count) AS total_count FROM suno2openai")
                     result = await cur.fetchone()
                     return result['total_count'] if result['total_count'] is not None else 0
-        except aiomysql.Error as e:
-            logging.error(f"Database error: {e}")
+        except Exception as e:
+            logging.error(f"Unexpected error: {e}")
+            return 0
+
+    # 获取有效的 cookies 的count总和
+    async def get_valid_cookies_count(self):
+        try:
+            async with self.pool.acquire() as conn:
+                async with conn.cursor(aiomysql.DictCursor) as cur:
+                    await cur.execute("SELECT COUNT(cookie) AS total_count FROM suno2openai WHERE count > 0")
+                    result = await cur.fetchone()
+                    return result['total_count'] if result['total_count'] is not None else 0
+        except Exception as e:
+            logging.error(f"Unexpected error: {e}")
             return 0
 
     # 获取 cookies

--- a/sql_uilts.py
+++ b/sql_uilts.py
@@ -215,11 +215,11 @@ class DatabaseManager:
                 await cur.execute("SELECT cookie FROM suno2openai")
                 return await cur.fetchall()
 
-    # 获取 invalid_cookies
+    # 获取无效的cookies
     async def get_invalid_cookies(self):
         async with self.pool.acquire() as conn:
             async with conn.cursor(aiomysql.DictCursor) as cur:
-                await cur.execute("SELECT cookie FROM suno2openai WHERE count > 0")
+                await cur.execute("SELECT cookie FROM suno2openai WHERE count < 0")
                 return await cur.fetchall()
 
     # 获取 cookies 和 count


### PR DESCRIPTION
### 本次PR的内容
1.  修复添加cookies的BUG，无效cookie也可以导入到数据库 #31 

2.  新增获取cookies详细信息
![image](https://github.com/wlhtea/Suno2openai/assets/132346501/d7bd7e91-10e4-4a2d-b2d6-f65cc98992aa)

3. 添加请求用于删除数据库里的无效的cookies，需要加上请求头`Authorization`和自定义请求前缀`COOKIES_PREFIX`
    * `COOKIES_PREFIX`/refresh/cookies `delete`: 用于删除数据库里的无效的cookies
    
![image](https://github.com/wlhtea/Suno2openai/assets/132346501/f0bc06c7-65ad-4cb1-b292-3a949246da77)
