### PR TITLE
🧩 解决并发问题，同时优化代码

### DIFF
--- a/main.py
+++ b/main.py
@@ -367,6 +367,8 @@ async def generate_data(chat_user_message, chat_id, timeStamp, ModelVersion, tag
             break
         except Exception as e:
             logging.error(f"第 {try_count + 1} 次尝试歌曲失败，错误为：{str(e)}")
+            if cookie is not None:
+                await Delelet_Songid(cookie)
             if try_count < retries - 1:
                 continue
             else:
@@ -513,7 +515,7 @@ async def add_cookies(data: schemas.Cookies, authorization: str = Header(...)):
         if not cookies:
             raise HTTPException(status_code=400, detail="Cookies 列表为空")
 
-        semaphore = asyncio.Semaphore(5)
+        semaphore = asyncio.Semaphore(20)
         add_tasks = []
 
         async def add_cookie(simple_cookie):
@@ -625,6 +627,22 @@ async def delete_invalid_cookies(authorization: str = Header(...)):
         raise http_exc
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": e})
+
+
+# 获取cookies的详细详细
+@app.delete(f"{COOKIES_PREFIX}/songID/cookies")
+async def get_cookies(authorization: str = Header(...)):
+    try:
+        await verify_auth_header(authorization)
+        rows_updated = await db_manager.delete_songIDS()
+        return JSONResponse(
+            content={"message": "Cookies songIDs更新成功！", "rows_updated": rows_updated}
+        )
+    except HTTPException as http_exc:
+        raise http_exc
+    except Exception as e:
+        logging.error(f"Unexpected error: {e}")
+        return JSONResponse(status_code=500, content={"error": str(e)})
 
 
 # 添加cookie的函数

--- a/main.py
+++ b/main.py
@@ -249,11 +249,11 @@ async def generate_data(chat_user_message, chat_id, timeStamp, ModelVersion, tag
             yield f"""data:""" + ' ' + f"""{json.dumps({"id": f"chatcmpl-{chat_id}", "object": "chat.completion.chunk", "model": "suno-v3", "created": timeStamp, "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}]})}\n\n"""
 
             response = await generate_music(data=data, token=token)
-            await asyncio.sleep(3)
+            # await asyncio.sleep(3)
             clip_ids = get_clips_ids(response)
             song_id_1 = clip_ids[0]
             song_id_2 = clip_ids[1]
-            await db_manager.update_song_ids_by_cookie(cookie, song_id_1, song_id_2)
+            # await db_manager.update_song_ids_by_cookie(cookie, song_id_1, song_id_2)
 
             for clip_id in clip_ids:
                 count = 0

--- a/main.py
+++ b/main.py
@@ -184,8 +184,8 @@ def get_clips_ids(response: json):
 #     return cookieSelected
 
 
-async def Delelet_Songid(songid):
-    return await db_manager.delete_song_ids(songid)
+async def Delelet_Songid(cookie):
+    return await db_manager.delete_song_ids(cookie)
 
 
 async def generate_data(chat_user_message, chat_id, timeStamp, ModelVersion, tags=None, title=None, continue_at=None,
@@ -271,7 +271,7 @@ async def generate_data(chat_user_message, chat_id, timeStamp, ModelVersion, tag
                     if not _return_Forever_url:
                         try:
                             if check_status_complete(now_data):
-                                await Delelet_Songid(clip_id)
+                                await Delelet_Songid(cookie)
                                 Aideo_Markdown_Conetent = (f""
                                                            f"\n## 🎷 永久音乐链接\n"
                                                            f"- **🎵 歌曲1️⃣**：{'https://cdn1.suno.ai/' + clip_id + '.mp3'} \n"

--- a/sql_uilts.py
+++ b/sql_uilts.py
@@ -97,16 +97,16 @@ class DatabaseManager:
             async with conn.cursor() as cursor:
                 try:
                     await cursor.execute('''
-                        SELECT cookie FROM suno2openai
+                        SELECT cookie FROM suno2openai 
                         WHERE songID IS NULL AND songID2 IS NULL AND count > 0
-                        ORDER BY RAND() LIMIT 1
-                        FOR UPDATE
+                        ORDER BY MD5(CONCAT(cookie, NOW()))
+                        LIMIT 1 FOR UPDATE;
                     ''')
                     row = await cursor.fetchone()
                     if row:
                         await cursor.execute('''
                             UPDATE suno2openai
-                            SET songID = %s, songID2 = %s
+                            SET count = count - 1, songID = %s, songID2 = %s, time = CURRENT_TIMESTAMP
                             WHERE cookie = %s
                         ''', ("tmp", "tmp", row[0]))
                         await conn.commit()

--- a/sql_uilts.py
+++ b/sql_uilts.py
@@ -113,10 +113,10 @@ class DatabaseManager:
                         await transaction.commit()
                         return row[0]
                     else:
-                        await transaction.rollback()
+                        transaction.rollback()
                         raise HTTPException(status_code=404, detail="Token not found")
             except Exception as e:
-                await transaction.rollback()
+                transaction.rollback()  
                 raise HTTPException(status_code=404, detail=f"{str(e)}")
 
     async def insert_or_update_cookie(self, cookie, songID=None, songID2=None, count=0):

--- a/sql_uilts.py
+++ b/sql_uilts.py
@@ -151,7 +151,7 @@ class DatabaseManager:
         else:
             return await self.get_token()
 
-    async def delete_song_ids(self, songid):
+    async def delete_song_ids(self, cookie):
         await self.create_pool()
         async with self.pool.acquire() as conn:
             try:
@@ -159,8 +159,8 @@ class DatabaseManager:
                     await cur.execute('''
                         UPDATE suno2openai
                         SET songID = NULL, songID2 = NULL
-                        WHERE songID = %s OR songID2 = %s
-                    ''', (songid, songid))
+                        WHERE cookie = %s
+                    ''', cookie)
                     await conn.commit()
             except Exception as e:
                 await conn.rollback()

--- a/sql_uilts.py
+++ b/sql_uilts.py
@@ -166,6 +166,23 @@ class DatabaseManager:
                 await conn.rollback()
                 raise HTTPException(status_code=500, detail=f"{str(e)}")
 
+    # 删除所有的songID
+    async def delete_songIDS(self):
+        await self.create_pool()
+        async with self.pool.acquire() as conn:
+            try:
+                async with conn.cursor() as cur:
+                    await cur.execute('''
+                        UPDATE suno2openai
+                        SET songID = NULL, songID2 = NULL;
+                    ''')
+                    await conn.commit()
+                    rows_updated = cur.rowcount
+                    return rows_updated
+            except Exception as e:
+                await conn.rollback()
+                raise HTTPException(status_code=500, detail=f"{str(e)}")
+
     async def update_cookie_count(self, cookie, count_increment, update=None):
         await self.create_pool()
         async with self.pool.acquire() as conn:

--- a/sql_uilts.py
+++ b/sql_uilts.py
@@ -99,7 +99,6 @@ class DatabaseManager:
                     await cursor.execute('''
                         SELECT cookie FROM suno2openai 
                         WHERE songID IS NULL AND songID2 IS NULL AND count > 0
-                        ORDER BY MD5(CONCAT(cookie, NOW()))
                         LIMIT 1 FOR UPDATE;
                     ''')
                     row = await cursor.fetchone()


### PR DESCRIPTION
### 本次PR的内容：

1. 新增接口`{COOKIES_PREFIX}`/songID/cookies  `delete` 用于还原cookies里的所有`songID`和`songID2`
3. 避免使用`aiomysql`的自动提交，改为手动提交，以适配事务
4. 使用悲观锁加事务用于解决并发问题
5. 优化代码结构，提高响应速度

### 已测试通过，可以通过`yangclivia/suno2openai:latest`镜像用于测试